### PR TITLE
lib/LDAPHandler: use bind DN/search bases for FreeIPA

### DIFF
--- a/README.mkdn
+++ b/README.mkdn
@@ -84,9 +84,10 @@ $ git clone https://github.com/ComputerScienceHouse/Drink-JS.git && cd Drink-JS
 
 ```
 exports.ldap = {
-    username: "",
+    bind_dn: "",
+    user_search_base: "cn=users,cn=accounts,dc=csh,dc=rit,dc=edu",
     password: "",
-    host: "ldap://ldap.csh.rit.edu",
+    host: "ldaps://stone.csh.rit.edu",
     version: 3
 }
 ```

--- a/lib/LDAPHandler.js
+++ b/lib/LDAPHandler.js
@@ -28,7 +28,7 @@ LDAPHandler.prototype = {
 
         self.ldap_config = require('../config/ldap_config.js').ldap;
 
-		self.ldap = new LDAP({ uri: self.ldap_config.host, verision: self.ldap_config.version });
+        self.ldap = new LDAP({ uri: self.ldap_config.host, verision: self.ldap_config.version });
 
         self.open(callback);
     },
@@ -55,18 +55,18 @@ LDAPHandler.prototype = {
 
         self.connect(function(err){
             var bind_options = {
-                binddn: 'uid=' + username + ',ou=Users,dc=csh,dc=rit,dc=edu',
+                binddn: 'uid=' + username + ',' + self.ldap_config.user_search_base,
                 password: password
             };
 
             self.ldap.simplebind(bind_options, function(msg_id, error){
                 if(typeof error == 'undefined'){
-    				var search_options = {
-    					base: 'ou=Users,dc=csh,dc=rit,dc=edu',
-    					filter: "(uid=" + username + ")",
-    					scope: '*',
-    					subtree: self.ldap.SUBTREE
-    				};
+                    var search_options = {
+                        base: self.ldap_config.user_search_base,
+                        filter: "(uid=" + username + ")",
+                        scope: '*',
+                        subtree: self.ldap.SUBTREE
+                    };
 
                     self.ldap.search(search_options, function(error, data){
                         if(typeof error === 'undefined'){
@@ -110,18 +110,18 @@ LDAPHandler.prototype = {
         self.connect(function(){
             
             var bind_options = {
-                binddn: 'cn=' + self.ldap_config.username + ',ou=Apps,dc=csh,dc=rit,dc=edu',
+                binddn: self.ldap_config.bind_dn,
                 password: self.ldap_config.password
             };
 
             self.ldap.simplebind(bind_options, function(msg_id, error){
                 if(typeof error == 'undefined'){
-    				var search_options = {
-    					base: 'ou=Users,dc=csh,dc=rit,dc=edu',
-    					filter: "(ibutton=" + ibutton + ")",
-    					scope: '*',
-    					subtree: self.ldap.SUBTREE
-    				};
+                    var search_options = {
+                        base: self.ldap_config.user_search_base,
+                        filter: "(ibutton=" + ibutton + ")",
+                        scope: '*',
+                        subtree: self.ldap.SUBTREE
+                    };
 
                     self.ldap.search(search_options, function(error, data){
                         if(typeof error == 'undefined'){
@@ -165,10 +165,10 @@ LDAPHandler.prototype = {
         var self = this;
 
         if(auth_type == 'ibutton' || auth_type == 'drink'){
-			var bind_options = {
-				binddn: 'cn=' + self.ldap_config.username + ',ou=Apps,dc=csh,dc=rit,dc=edu',
-				password: self.ldap_config.password
-			};
+            var bind_options = {
+                binddn: self.ldap_config.bind_dn,
+                password: self.ldap_config.password
+            };
 
             self.connect(function(){
                 self.ldap.simplebind(bind_options, function(msg_id, error){
@@ -177,10 +177,10 @@ LDAPHandler.prototype = {
             });
         } else {
 
-			var bind_options = {
-				binddn: 'uid=' + credentials.username + ',ou=Users,dc=csh,dc=rit,dc=edu',
-				password: credentials.password
-			};
+            var bind_options = {
+                binddn: 'uid=' + credentials.username + ',' + self.ldap_config.user_search_base,
+                password: credentials.password
+            };
 
             self.connect(function(){
                 self.ldap.simplebind(bind_options, function(msg_id, error){
@@ -207,12 +207,12 @@ LDAPHandler.prototype = {
                     search_query = 'uid=' + credentials.username;
                 }
 
-				var search_options = {
-					base: 'ou=Users,dc=csh,dc=rit,dc=edu',
-					filter: "(" + search_query + ")",
-					scope: '*',
-					subtree: self.ldap.SUBTREE
-				};
+                var search_options = {
+                    base: self.ldap_config.user_search_base,
+                    filter: "(" + search_query + ")",
+                    scope: '*',
+                    subtree: self.ldap.SUBTREE
+                };
 
 
                 self.ldap.search(search_options, function(error, data){
@@ -247,12 +247,12 @@ LDAPHandler.prototype = {
             if(typeof error == 'undefined'){
                 var search_query = 'uid=' + username;
 				
-				var search_options = {
-					base: 'ou=Users,dc=csh,dc=rit,dc=edu',
-					filter: "(" + search_query + ")",
-					scope: '*',
-					subtree: self.ldap.SUBTREE
-				};
+                var search_options = {
+                    base: self.ldap_config.user_search_base,
+                    filter: "(" + search_query + ")",
+                    scope: '*',
+                    subtree: self.ldap.SUBTREE
+                };
 
                 self.ldap.search(search_options, function(error, data){
                     if(typeof error == 'undefined'){
@@ -280,7 +280,7 @@ LDAPHandler.prototype = {
     update_balance: function(uid, new_balance, callback){
         var self = this,
             auth_type = 'drink',
-            dn = 'uid=' + uid + ',ou=Users,dc=csh,dc=rit,dc=edu',
+            dn = 'uid=' + uid + ',' + self.ldap_config.user_search_base,
             bal = [
                 {
                     attr: "drinkBalance",


### PR DESCRIPTION
This switches over the LDAP configuration to use (or expose as config knobs) the appropriate values for the new FreeIPA schema. This PR notably does *not* fix Drink admin detection to use the new group instead of the profile attribute, so that will also need to be done before DrinkJS will work completely with FreeIPA. I also snuck in some retabbing in the LDAP handler.